### PR TITLE
Fix invalid console import in WhatsApp controller

### DIFF
--- a/backend/src/controller/Whatsapp.ts
+++ b/backend/src/controller/Whatsapp.ts
@@ -4,7 +4,6 @@ import Mensagens from "../entities/APIMK/Mensagens";
 import Conversations from "../entities/APIMK/Conversations";
 import Conversation_Users from "../entities/APIMK/Conversation_Users";
 import PeopleConversations from "../entities/APIMK/People_Conversations";
-import { time } from "console";
 import { In } from "typeorm";
 import axios from "axios";
 


### PR DESCRIPTION
## Summary
- remove erroneous `import { time } from "console"` line

## Testing
- `npm run build` *(fails: Cannot find module 'express', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685573652abc832badb59736ae89e9a8