### PR TITLE
Send technical evaluation via WhatsApp

### DIFF
--- a/backend/src/controller/ChamadoFichaTecnica.ts
+++ b/backend/src/controller/ChamadoFichaTecnica.ts
@@ -8,6 +8,7 @@ import { AprDados, ChamadoFichaTecnica } from "../entities/ChamadoFichaTecnica";
 import { ChamadosEntities } from "../entities/ChamadosEntities";
 import { SisMsg } from "../entities/SisMsg";
 import { montarPdfFichaTecnica } from "../services/FichaTecnicaPdf";
+import { enviarAvaliacaoDaFicha } from "../services/AvaliacaoTecnica";
 
 type Equipamento = {
   tipo: string;
@@ -243,6 +244,10 @@ class ChamadoFichaTecnicaController {
         salva.mkauth_chamado_id = ultimoChamado.chamado;
         salva.mkauth_erro = undefined as any;
         await repo.save(salva);
+
+        // Chamado concluído: o cliente recebe a pesquisa de satisfação de cada
+        // técnico que atendeu. Falha aqui não invalida a ficha.
+        void enviarAvaliacaoDaFicha(salva);
       } catch (mkErr: any) {
         salva.mkauth_sincronizado = false;
         salva.mkauth_erro =
@@ -455,6 +460,9 @@ class ChamadoFichaTecnicaController {
         ficha.mkauth_sincronizado = true;
         ficha.mkauth_chamado_id = resultado.chamadoId;
         ficha.mkauth_erro = undefined as any;
+        // Cobre a ficha cujo envio original falhou; o carimbo de data evita
+        // mandar a pesquisa duas vezes.
+        void enviarAvaliacaoDaFicha(ficha);
       } else {
         ficha.mkauth_sincronizado = false;
         ficha.mkauth_erro = resultado.erro;

--- a/backend/src/entities/ChamadoFichaTecnica.ts
+++ b/backend/src/entities/ChamadoFichaTecnica.ts
@@ -137,6 +137,10 @@ export class ChamadoFichaTecnica {
   @CreateDateColumn({ type: "timestamp" })
   criado_em?: Date;
 
+  /** Quando a pesquisa de satisfação foi enviada ao cliente (uma vez só). */
+  @Column({ type: "timestamp", nullable: true })
+  avaliacao_enviada_em?: Date | null;
+
   @Column({ type: "varchar", length: 64, nullable: true })
   mkauth_chamado_id?: string;
 

--- a/backend/src/migration/1783100000000-AddAvaliacaoEnviadaToFichaTecnica.ts
+++ b/backend/src/migration/1783100000000-AddAvaliacaoEnviadaToFichaTecnica.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddAvaliacaoEnviadaToFichaTecnica1783100000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      "chamados_ficha_tecnica",
+      new TableColumn({
+        name: "avaliacao_enviada_em",
+        type: "timestamp",
+        isNullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn(
+      "chamados_ficha_tecnica",
+      "avaliacao_enviada_em",
+    );
+  }
+}

--- a/backend/src/services/AvaliacaoTecnica.ts
+++ b/backend/src/services/AvaliacaoTecnica.ts
@@ -1,0 +1,117 @@
+import { v4 as uuidv4 } from "uuid";
+import AppDataSource from "../database/DataSource";
+import MkauthSource from "../database/MkauthSource";
+import { Feedback } from "../entities/NotaColaboradores";
+import { ClientesEntities } from "../entities/ClientesEntities";
+import { ChamadoFichaTecnica } from "../entities/ChamadoFichaTecnica";
+import Whatsapp from "../controller/Whatsapp";
+
+/**
+ * Template aprovado na Meta. O corpo recebe, nesta ordem:
+ * {{1}} nome do técnico, {{2}} link da pesquisa.
+ */
+const TEMPLATE = "avaliacao_tecnica";
+
+const FRONT_URL = (process.env.URL || "http://localhost:3001").replace(
+  /\/$/,
+  "",
+);
+
+/** Celular no formato aceito pela API do WhatsApp (55 + DDD + número). */
+function normalizarCelular(bruto?: string | null): string | null {
+  const digitos = String(bruto ?? "").replace(/\D/g, "");
+  if (digitos.length < 10) return null;
+  return digitos.startsWith("55") ? digitos : `55${digitos}`;
+}
+
+/**
+ * A ficha guarda o técnico em caixa alta ("ARNALDO"); a pesquisa usa o nome
+ * como ele aparece na tela de avaliações ("Arnaldo").
+ */
+function formatarNome(nome: string): string {
+  return nome
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join(" ");
+}
+
+/** Técnicos que estiveram no chamado, sem repetir e sem "NENHUM". */
+function tecnicosDaFicha(ficha: ChamadoFichaTecnica): string[] {
+  const nomes = [ficha.tec_externo, ficha.tec_interno]
+    .map((t) => String(t ?? "").trim())
+    .filter((t) => t && t.toUpperCase() !== "NENHUM")
+    .map(formatarNome);
+  return [...new Set(nomes)];
+}
+
+/**
+ * Ao concluir a ficha técnica, manda ao cliente a mesma pesquisa da tela de
+ * avaliações — um link por técnico que atendeu.
+ *
+ * Nunca lança: uma falha no WhatsApp não pode derrubar o fechamento da ficha.
+ */
+export async function enviarAvaliacaoDaFicha(
+  ficha: ChamadoFichaTecnica,
+): Promise<{ enviados: number; erro?: string }> {
+  try {
+    // Ressincronizar a ficha não pode disparar a pesquisa de novo.
+    if (ficha.avaliacao_enviada_em) return { enviados: 0 };
+
+    const tecnicos = tecnicosDaFicha(ficha);
+    if (tecnicos.length === 0) return { enviados: 0 };
+
+    const cliente = await MkauthSource.getRepository(ClientesEntities).findOne({
+      where: { login: ficha.usuario },
+    });
+    const celular = normalizarCelular(cliente?.celular || cliente?.fone);
+    if (!celular) {
+      const erro = `Cliente ${ficha.usuario} sem celular válido no cadastro.`;
+      console.error(`[AvaliacaoTecnica] ${erro}`);
+      return { enviados: 0, erro };
+    }
+
+    const feedbackRepo = AppDataSource.getRepository(Feedback);
+    let enviados = 0;
+
+    for (const tecnico of tecnicos) {
+      const identificador = uuidv4();
+      await feedbackRepo.save(
+        feedbackRepo.create({
+          unique_identifier: identificador,
+          login: tecnico,
+        }),
+      );
+
+      const link = `${FRONT_URL}/feedback/${encodeURIComponent(tecnico)}/${identificador}`;
+      try {
+        await Whatsapp.MensagemTemplate(celular, TEMPLATE, "pt_BR", [
+          tecnico,
+          link,
+        ]);
+        enviados += 1;
+        console.log(
+          `[AvaliacaoTecnica] Pesquisa do técnico ${tecnico} enviada para ${celular} (chamado ${ficha.chamado_number}): ${link}`,
+        );
+      } catch (e: any) {
+        // O link já existe no banco: o atendimento consegue reenviar pela tela
+        // de avaliações se o WhatsApp falhar.
+        console.error(
+          `[AvaliacaoTecnica] Falha ao enviar pesquisa do técnico ${tecnico}:`,
+          e?.response?.data || e?.message || e,
+        );
+      }
+    }
+
+    if (enviados > 0) {
+      ficha.avaliacao_enviada_em = new Date();
+      await AppDataSource.getRepository(ChamadoFichaTecnica).save(ficha);
+    }
+
+    return { enviados };
+  } catch (error: any) {
+    console.error("[AvaliacaoTecnica] Erro inesperado:", error);
+    return { enviados: 0, erro: error?.message };
+  }
+}


### PR DESCRIPTION
Add automated sending of technician evaluations when a ficha técnica is completed. Introduces a new AvaliacaoTecnica service that creates Feedback records, formats technician names, normalizes client phones, and sends a Meta template (avaliacao_tecnica) via WhatsApp. Adds avaliacao_enviada_em timestamp to ChamadoFichaTecnica (with migration) to ensure idempotency. Triggers added to ChamadoFichaTecnica controller after successful sync/creation; failures are logged and do not block ficha completion.